### PR TITLE
feat: Update MongoDB connection URI in application.properties

### DIFF
--- a/backend/API/src/main/resources/application.properties
+++ b/backend/API/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-spring.data.mongodb.host=localhost
-spring.data.mongodb.port=27017
-#spring.data.mongodb.uri=${MONGODB_URI:mongodb+srv://vercel-admin-user:2Inz8Qc0m8j2cw1F@cluster0.7oyttmj.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0}
+#spring.data.mongodb.host=localhost
+#spring.data.mongodb.port=27017
+spring.data.mongodb.uri=${MONGODB_URI:mongodb+srv://vercel-admin-user:2Inz8Qc0m8j2cw1F@cluster0.7oyttmj.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0}
 spring.data.mongodb.database=clover
 
 api.security.token.secret=${JWT_SECRET:123456789}


### PR DESCRIPTION
This commit updates the MongoDB connection URI in the application.properties file. The new URI points to the MongoDB Atlas cluster hosted on the cluster0.7oyttmj.mongodb.net server. This change allows the application to connect to the remote MongoDB database for data storage and retrieval.